### PR TITLE
Remove version from show-plugin btest in prep for Bro 2.7

### DIFF
--- a/tests/Baseline/tcprs.show-plugin/output
+++ b/tests/Baseline/tcprs.show-plugin/output
@@ -1,4 +1,4 @@
-jswaro::TCPRS - A TCP retransmission and network reordering detection and classification analyzer (dynamic, version 0.2)
+jswaro::TCPRS - A TCP retransmission and network reordering detection and classification analyzer (dynamic, version)
     [Analyzer] TCPRS (ANALYZER_TCPRS, enabled)
     [Function] TCPRS::EnableTCPRSAnalyzer
     [Event] TCPRS::conn_spurious_dsack

--- a/tests/tcprs/show-plugin.bro
+++ b/tests/tcprs/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN jswaro::TCPRS >output
+# @TEST-EXEC: bro -NN jswaro::TCPRS |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.