### PR TITLE
Fix test_command

### DIFF
--- a/bro-pkg.meta
+++ b/bro-pkg.meta
@@ -4,4 +4,4 @@ tags = bro plugin, TCP, retransmission, connection state, conn, input reader, pr
 build_command = ( ./configure --bro-dist=%(bro_dist)s && make )
 plugin_dir = build
 script_dir = scripts
-test_command = cd tests btest -d tcprs
+test_command = cd tests && btest -d tcprs


### PR DESCRIPTION
The previous `test_command` succeeded for the wrong reason: `bro-pkg`
runs tests under the bourne-shell (`sh`) by default and, unfortunately,
it's perfectly fine with `cd <dir> <whatever other bogus stuff>`
As long as that initial `<dir>` argument exists, it silently eats
the rest, so the tests weren't actually being run in this case.